### PR TITLE
KoreanStudent 계정관련 CRUD & Section 학기 관리 CRUD

### DIFF
--- a/E_Global_Zone/app/Http/Controllers/KoreanController.php
+++ b/E_Global_Zone/app/Http/Controllers/KoreanController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Student_korean;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 
 class KoreanController extends Controller
 {
@@ -14,23 +15,52 @@ class KoreanController extends Controller
      */
     public function indexApproval()
     {
-        //
+        //TODO 검색이 안된다.. 왜그러지?
+        $approval_result = Student_korean::where('std_kor_dept', 2);
+
+        return response()->json([
+            'message' => '회원가입 승인 대기중인 한국인 리스트 반환.',
+            'data' => $approval_result
+        ], 201);
     }
 
     /**
      * 계정 등록 - 승인
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function updateApproval(Request $request, $id)
+    public function updateApproval(Request $request)
     {
-        //
+        $data = json_decode($request->getContent(), true);
+
+        // 한국인 학생 계정 승인여부 반환
+        foreach ($data['approval'] as $approval) {
+            $validator = Validator::make($approval, [
+                'std_kor_id' => 'required|integer',
+                'std_kor_state_of_permission' => 'required|boolean',
+            ]);
+
+            if ($validator->fails()) {
+                return response()->json([
+                    'message' => $validator->errors(),
+                ], 422);
+            }
+
+            $korean = Student_korean::find($approval['std_kor_id']);
+
+            $korean->std_kor_state_of_permission = $approval['std_kor_state_of_permission'];
+
+            $korean->save();
+        }
+
+        return response()->json([
+            'message' => '계정 승인 완료.',
+        ], 200);
     }
 
     /**
-     * 학년도별 한국인 학생 정보 조회
+     * 전체 한국인 학생 정보 조회
      *
      * @return \Illuminate\Http\Response
      */
@@ -49,30 +79,50 @@ class KoreanController extends Controller
      */
     public function registerAccount(Request $request)
     {
-        //
-    }
+        $validator = Validator::make($request->all(), [
+            'std_kor_id' => 'required|integer|min:7',
+            'std_kor_dept' => 'required|integer',
+            'std_kor_name' => 'required|string|min:2',
+            'std_kor_phone' => 'required|string|min:13',
+            'std_kor_mail' => 'required|email',
+        ]);
 
-    /**
-     * 비밀번호 초기화
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function resetAccount(Request $request, $id)
-    {
-        //
+        // 지슈트 g.yju.ac.kr 이메일 벨리데이션 검사
+        $check_email = explode('@', $request->std_kor_mail)[1];
+        $check_email = strcmp($check_email, 'g.yju.ac.kr');
+
+        if ($validator->fails() || $check_email) {
+            return response()->json([
+                'message' => $check_email ? "G Suite 계정만 가입 가능합니다." : $validator->errors(),
+            ], 422);
+        }
+
+        $create_student = Student_korean::create([
+            'std_kor_id' => $request->std_kor_id,
+            'std_kor_dept' => $request->std_kor_dept,
+            'std_kor_name' => $request->std_kor_name,
+            'std_kor_phone' => $request->std_kor_phone,
+            'std_kor_mail' => $request->std_kor_mail,
+        ]);
+
+        return response()->json([
+            'message' => '한국인 학생 계정 생성 완료',
+        ], 201);
     }
 
     /**
      * 계정 삭제
      *
-     * @param  int  $id
+     * @param  int  $std_kor_id
      * @return \Illuminate\Http\Response
      */
-    public function destroyAccount($id)
+    public function destroyAccount(Student_korean $std_kor_id)
     {
-        //
+        $std_kor_id->delete();
+
+        return response()->json([
+            'message' => '계정 삭제 완료',
+        ], 204);
     }
 
     /**

--- a/E_Global_Zone/app/Http/Controllers/ReservationController.php
+++ b/E_Global_Zone/app/Http/Controllers/ReservationController.php
@@ -79,41 +79,6 @@ class ReservationController extends Controller
         ], 200);
     }
 
-    // /**
-    //  * 한국인학생 - 내 예약 일정 조회
-    //  *
-    //  * @return \Illuminate\Http\Response
-    //  */
-    // public function show()
-    // {
-    //     // 사용자 정보 -> 학번 가져오기.
-    //     $res_std_kor = 1955408;
-    //     $result_reservations = Reservation::where('res_std_kor', $res_std_kor)
-    //         ->where(function ($query) {
-    //             $query->orwhere('res_state_of_permission', '!=', true)
-    //                 ->orwhere('res_state_of_attendance', '!=', true);
-    //         })
-    //         ->get();
-
-    //     foreach ($result_reservations as $reservation) {
-    //         // 스케줄 정보 추가.
-    //         $schedule_data = Schedule::find($reservation->res_sch);
-    //         $reservation->{"res_sch"} = $schedule_data;
-
-    //         // 유학생 정보 추가.
-    //         $foreigner_data = Student_foreigner::where('std_for_id', $schedule_data->sch_std_for)
-    //             ->select('std_for_id', 'std_for_lang', 'std_for_contry')
-    //             ->get()->first();
-
-    //         $schedule_data->{"sch_std_for"} = $foreigner_data;
-    //     }
-
-    //     return response()->json([
-    //         'message' => '진행중인 예약 조회 완료',
-    //         'result' => $result_reservations,
-    //     ], 200);
-    // }
-
     /**
      * 한국인학생 - 내 예약 일정 삭제
      *
@@ -141,12 +106,6 @@ class ReservationController extends Controller
         ->join('student_koreans as kor', 'kor.std_kor_id', 'reservations.res_std_kor')
         ->where('reservations.res_sch', $sch_id)
         ->get();
-
-        // 각 예약에 대한 한국인 학생 정보 추가.
-        // foreach ($result_foreigner_reservation as $reservation) {
-        //     $student_data = Student_korean::where('std_kor_id', $reservation->res_std_kor)->get()->first();
-        //     $reservation->{"res_std_kor"} = $student_data;
-        // }
 
         return response()->json([
             'message' => '해당 스케줄에 대한 예약 조회 성공.',
@@ -229,8 +188,9 @@ class ReservationController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function storeResult(Request $request)
+    public function updateResult(Request $request)
     {
+        //TODO 사진 업로드 기능 추가해야 함.
         $data = json_decode($request->getContent(), true);
 
         // 각 예약에 대한 한국인 학생 결과 업데이트

--- a/E_Global_Zone/app/Http/Controllers/SectionController.php
+++ b/E_Global_Zone/app/Http/Controllers/SectionController.php
@@ -2,83 +2,102 @@
 
 namespace App\Http\Controllers;
 
+use App\Section;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 
 class SectionController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * 등록된 전체 학기 목록 조회
      *
      * @return \Illuminate\Http\Response
      */
     public function index()
     {
-        //
+        return response()->json([
+            'message' => '등록된 학기 목록 조회',
+            'result' => Section::all(),
+        ], 200);
     }
 
     /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
+     * 학기 등록
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
     public function store(Request $request)
     {
-        //
+        $validator = Validator::make($request->all(), [
+            'sect_name' => 'required|string',
+            'sect_start_date' => 'required|date',
+            'sect_end_date' => 'required|date',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => $validator->errors(),
+            ], 422);
+        }
+
+        $create_section = Section::create([
+            'sect_name' => $request->sect_name,
+            'sect_start_date' => $request->sect_start_date,
+            'sect_end_date' => $request->sect_end_date,
+        ]);
+
+        return response()->json([
+            'message' => '학기 등록 완료',
+            'result' => $create_section,
+        ], 201);
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function show($id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function edit($id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
+     * 학기 수정
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
+     * @param  int  $sect_id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(Request $request, Section $sect_id)
     {
-        //
+        $validator = Validator::make($request->all(), [
+            'sect_name' => 'required|string',
+            'sect_start_date' => 'required|date',
+            'sect_end_date' => 'required|date',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => $validator->errors(),
+            ], 422);
+        }
+
+        $update_section = $sect_id->update([
+            'sect_name' => $request->sect_name,
+            'sect_start_date' => $request->sect_start_date,
+            'sect_end_date' => $request->sect_end_date,
+        ]);
+
+        return response()->json([
+            'message' => '스케줄 업데이트 완료',
+            'result' => $update_section,
+        ], 200);
     }
 
     /**
-     * Remove the specified resource from storage.
+     * 학기 삭제
      *
-     * @param  int  $id
+     * @param  int  $sect_id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id)
+    public function destroy(Section $sect_id)
     {
-        //
+        $sect_id->delete();
+
+        return response()->json([
+            'message' => '학기 삭제 완료',
+        ], 204);
     }
 }

--- a/E_Global_Zone/app/Section.php
+++ b/E_Global_Zone/app/Section.php
@@ -22,4 +22,6 @@ class Section extends Model
         'sect_start_date',
         'sect_end_date'
     ];
+
+    public $timestamps = false;
 }

--- a/E_Global_Zone/routes/api.php
+++ b/E_Global_Zone/routes/api.php
@@ -61,25 +61,38 @@ Route::prefix('/admin')->group(function () {
         /** 계정 등록 - 대기 명단 조회 */
         Route::get('approval', 'KoreanController@indexApproval')->name('koreans.indexApproval');
         /** 계정 등록 - 승인 */
-        Route::put('approval', 'KoreanController@updateApproval')->name('koreans.updateApproval');
+        Route::patch('approval', 'KoreanController@updateApproval')->name('koreans.updateApproval');
 
-        /** 학년도별 한국인 학생 정보 조회 */
-        Route::get('{id}', 'KoreanController@index')->name('koreans.index');
+        /** 전체 한국인 학생 정보 조회 */
+        Route::get('', 'KoreanController@index')->name('koreans.index');
 
         /** 한국인 학생 계정 생성 */
         Route::post('account', 'KoreanController@registerAccount')->name('koreans.registerAccount');
-        /** 비밀번호 초기화 */
-        Route::put('account/{id}', 'KoreanController@resetAccount')->name('koreans.resetAccount');
         /** 계정 삭제 */
-        Route::delete('account/{id}', 'KoreanController@destroyAccount')->name('koreans.destroyAccount');
+        Route::delete('account/{std_kor_id}', 'KoreanController@destroyAccount')->name('koreans.destroyAccount');
 
         /** 이용 제한 등록 */
-        Route::get('restrict/{id}', 'RestrictKoreanController@indexRestrict')->name('koreans.indexRestrict');
+        Route::get('restrict/{std_kor_id}', 'RestrictKoreanController@indexRestrict')->name('koreans.indexRestrict');
         /** 이용 제한 해제 */
-        Route::delete('restrict/{id}', 'RestrictKoreanController@destroyRestrict')->name('koreans.destroyRestrict');
+        Route::delete('restrict/{std_kor_id}', 'RestrictKoreanController@destroyRestrict')->name('koreans.destroyRestrict');
 
         /** 학년도별 학생정보 CSV 파일 다운로드 */
         // Route::get('data/{id}', 'KoreanController@csv')->name('koreans.csv');
+    });
+
+    /* 학기 관리 라우터 */
+    Route::prefix('/section')->group(function () {
+        /** 등록된 전체 학기 목록 조회 */
+        Route::get('', 'SectionController@index')->name('sections.index');
+
+        /** 학기 등록 */
+        Route::post('', 'SectionController@store')->name('sections.store');
+
+        /** 학기 수정 */
+        Route::patch('{sect_id}', 'SectionController@update')->name('sections.update');
+
+        /** 학기 삭제 */
+        Route::delete('{sect_id}', 'SectionController@destroy')->name('sections.destroy');
     });
 });
 
@@ -90,9 +103,9 @@ Route::prefix('/foreigner')->group(function () {
         /** 해당 스케줄 신청 학생 명단 조회 */
         Route::get('{sch_id}', 'ReservationController@showReservation')->name('reservations.showReservation');
         /** 해당 스케줄 신청 학생 명단 승인 */
-        Route::patch('', 'ReservationController@updateReservaion')->name('reservations.updateReservaion');
+        Route::patch('/approve', 'ReservationController@updateReservaion')->name('reservations.updateReservaion');
         /** 해당 스케줄 출석 결과 입력 */
-        Route::post('', 'ReservationController@storeResult')->name('reservations.storeResult');
+        Route::patch('/result', 'ReservationController@updateResult')->name('reservations.updateResult');
     });
 });
 


### PR DESCRIPTION
- ### 계정 관련
1. 계정 등록 - 대기 명단 조회
2. 계정 등록 - 회원 가입 승인
3. 전체 한국인 학생 정보 조회
4. 한국인 학생 계정 생성
5. 한국인 학생 계정 삭제

- ### 학기 관리
1. 등록 된 전체 학기 목록 조회
2. 학기 등록
3. 학기 정보 수정
4. 학기 정보 삭제
---
- ### Todo List

- [ ] 계정 등록 -> 대기 명단 조회 where절 조회 오류. (컬럼을 수정해도 조회 불가능)
- [ ] 사진 업로드 기능 추가.