### PR TITLE
Schedule - 스케줄 등록 자동 쿼리

### DIFF
--- a/E_Global_Zone/app/Http/Controllers/ForeignerController.php
+++ b/E_Global_Zone/app/Http/Controllers/ForeignerController.php
@@ -133,7 +133,7 @@ class ForeignerController extends Controller
         //TODO 비밀번호 길이 조정.
         $validator = Validator::make($request->all(), [
             'std_for_id' => 'required|integer|min:7',
-            'std_for_passwd' => 'required|string',
+            'std_for_passwd' => 'required|string|min:8',
             'std_for_dept' => 'required|integer',
             'std_for_name' => 'required|string|min:2',
             'std_for_lang' => 'required|string|min:2',
@@ -153,7 +153,7 @@ class ForeignerController extends Controller
         try {
             Student_foreigner::create([
                 'std_for_id' => $request->std_for_id,
-                'std_for_passwd' => $request->std_for_passwd,
+                'password' => Hash::make($request->std_for_passwd),
                 'std_for_dept' => $request->std_for_dept,
                 'std_for_name' => $request->std_for_name,
                 'std_for_lang' => $request->std_for_lang,
@@ -189,11 +189,12 @@ class ForeignerController extends Controller
     public function updateAccount(Student_foreigner $std_for_id, Request $request)
     {
         $is_user_admin = true;                                          /* 관리자 인증 여부 */
+        //TODO 리셋 비밀번호 env에 저장하기.
         $user_password = "1q2w3e4r!";
 
         if (!$is_user_admin) {
             $validator = Validator::make($request->all(), [
-                'std_for_passwd' => 'required|string',
+                'std_for_passwd' => 'required|string|min:8',
             ]);
 
             if ($validator->fails()) {
@@ -207,7 +208,7 @@ class ForeignerController extends Controller
         }
 
         $std_for_id->update([
-            'std_for_passwd' => $user_password,
+            'password' => Hash::make($user_password),
         ]);
 
         return response()->json([

--- a/E_Global_Zone/app/Http/Controllers/LoginController.php
+++ b/E_Global_Zone/app/Http/Controllers/LoginController.php
@@ -36,6 +36,7 @@ class LoginController extends Controller
         array $rules
     ): bool
     {
+        //TODO password HASH 처리!!
         $this->validator = Validator::make($request->all(), [
             $rules['key'] => 'required|string',
             'password' => 'required|string|min:8',


### PR DESCRIPTION
- ScheduleController
스케줄 등록 자동 쿼리 완성.

- [ ] 시작  / 종료 시간 Setting DB에서 가져온 후 적용하기.

- - -

`프론트에서 보내줄때 아래 형식으로 맞춰주세요.`
sect_id : 학기 아이디,
schedule->요일->외국인학생 학번->[ 시간, 시간, 시간, .. ],
ecept_date : [ 제외날짜 목록 ... ]
```javascript
{
    "sect_id": 4,
    "schedule": {
        "월": {
            "1321705": [9,10,11,15],
            "1418547": [9,10,11,15],
            "2050262": [9,10,11,15],
            "2085331": [9,10,11,15],
            "1691065": [9,10,11,15]
        },
        "화": {
            "1691065": [9,10,11,15]
        },
        "수": {
            "1691065": [9,10,11,15]
        },
        "목": {
            "1418547": [9,10,11,15]
        },
        "금": {
            "1418547": [9,10,11,15]
        }
    },
    "ecept_date": [
        "2020-08-08",
        "2020-08-13",
        "2020-08-20",
        "2020-08-22"
    ]
}
```