### PR TITLE
Refactoring :: API 알고리즘 업데이트

### DIFF
--- a/E_Global_Zone/app/Http/Controllers/ScheduleController.php
+++ b/E_Global_Zone/app/Http/Controllers/ScheduleController.php
@@ -12,6 +12,14 @@ use Illuminate\Support\Facades\Validator;
 
 class ScheduleController extends Controller
 {
+    /*
+     * ========== TEST 완료 ==========
+     * 1. 한국인 학생 - 현재 날짜 기준 예약 가능 스케줄 조회(refactoring 필요)
+     * 2. 한국인 학생 - 특정 스케줄 조회(TODO 미완성 - 예외 요소 확인 필요)
+     * 3. 유학생 - 특정 기간 전체 스케줄 조회
+     * 4. 관리자 - 특정 날짜 전체 유학생 스케줄 조회
+     */
+
     private const _SCHEDULE_SEARCH_RES_SUCCESS = " 일자 유학생 스케줄을 반환합니다.";
     private const _SCHEDULE_SEARCH_RES_FAILURE = " 일자 유학생 스케줄을 조회에 실패하였습니다.";
 
@@ -417,14 +425,6 @@ class ScheduleController extends Controller
             'message' => '출석 결과 승인',
         ], 200);
     }
-
-
-    /*
-     * ========== TEST 완료 ==========
-     * 1. 한국인 학생 - 현재 날짜 기준 예약 가능 스케줄 조회(refactoring 필요)
-     * 2. 한국인 학생 - 특정 스케줄 조회(TODO 미완성 - 예외 요소 확인 필요)
-     * 3. 유학생 - 특정 날짜에 대한 개인 스케줄 조회
-     */
 
     /**
      * 한국인학생 - 현재 날짜 기준 예약 가능 스케줄 조회

--- a/E_Global_Zone/app/Http/Controllers/ScheduleController.php
+++ b/E_Global_Zone/app/Http/Controllers/ScheduleController.php
@@ -68,9 +68,9 @@ class ScheduleController extends Controller
         // -->>
 
         $is_sch_no_data = $response_data->count();
-        // TODO 데이터가 없을 경우 response 하는 것(여기)
-//        if ()
-//        dd($response_data->count());
+
+        if($is_sch_no_data) return self::response_json(self::_STD_FOR_SHOW_SCH_NO_DATA, 202);
+
         return
             self::response_json(self::_STD_FOR_SHOW_SCH_SUCCESS, 200, $response_data);
     }

--- a/E_Global_Zone/app/Reservation.php
+++ b/E_Global_Zone/app/Reservation.php
@@ -68,31 +68,27 @@ class Reservation extends Model
      * @param string $search_date
      * @return JsonResponse
      */
-    // TODO 한국인 학생 조회 기준 확인 필요
     public function get_std_kor_res_by_date(
         int $std_kor_id,
-//        string $std_kor_mail,
         string $search_date
     ): JsonResponse
     {
-        // TODO (여기) 줌 id 붙여줘야 함
         $lookup_columns = [
             'std_for_lang', 'std_for_name',
             'sch_start_date', 'sch_end_date',
             'res_state_of_permission', 'res_state_of_attendance',
             'sch_state_of_result_input', 'sch_state_of_permission',
-            'std_for_id', 'sch_for_zoom_pw'
+            'for.std_for_id', 'std_for_zoom_id', 'sch_for_zoom_pw'
         ];
 
         $result =
             self::select($lookup_columns)
                 ->join('schedules as sch', 'sch.sch_id', 'reservations.res_sch')
                 ->join('student_foreigners as for', 'for.std_for_id', 'sch.sch_std_for')
+                ->join('student_foreigners_contacts as contact', 'for.std_for_id', 'contact.std_for_id')
                 ->where('reservations.res_std_kor', $std_kor_id)
                 ->whereDate('sch.sch_start_date', $search_date)
                 ->get();
-
-        $result->join('student_foreigners_contacts as for_cont', 'for_cont.std_for_id', 'std_for_id');
 
         $is_std_kor_res_no_date = $result->count();
 

--- a/E_Global_Zone/routes/api.php
+++ b/E_Global_Zone/routes/api.php
@@ -100,8 +100,8 @@ Route::prefix('/admin')->group(function () {
 
     /* 스케줄 관리 라우터 */
     Route::prefix('/schedule')->group(function () {
-        /* 해당 일자 스케줄 조회 */
-        Route::get('{date}', 'ScheduleController@showForeignerSchedules')->name('schedules.showForeignerSchedules');
+        /* 특정 날짜 전체 유학생 스케줄 조회 */
+        Route::get('', 'ScheduleController@showForeignerSchedules')->name('schedules.showForeignerSchedules');
 
         /* 스케줄 등록 */
         Route::post('', 'ScheduleController@store')->name('schedules.store');

--- a/E_Global_Zone/routes/api.php
+++ b/E_Global_Zone/routes/api.php
@@ -196,8 +196,8 @@ Route::prefix('/korean')->group(function () {
         /** 내 예약 일정 삭제 */
         Route::delete('{res_id}', 'ReservationController@std_kor_destroy_res')->name('reservations.destroy');
 
-        /** 학기별 참석 결과 조회 */
-        // Route::get('', 'ReservationController@showResult')->name('reservations.show');
+        /** 학기별 미팅 목록 결과 조회 */
+        Route::get('/result', 'ReservationController@std_kor_show_res_by_sect')->name('reservations.show');
     });
 });
 

--- a/E_Global_Zone/routes/api.php
+++ b/E_Global_Zone/routes/api.php
@@ -150,7 +150,7 @@ Route::prefix('/admin')->group(function () {
 
 /* 유학생 라우터 */
 Route::prefix('foreigner')->group(function () {
-    /* 유학생 - 특정 날짜 개인 스케줄 조회 */
+    /* 유학생 - 특정 기간 개인 스케줄 조회 */
     Route::get('schedule', 'ScheduleController@std_for_show_sch_by_date')->name('schedules.show');
 
     /** 등록된 계열 & 학과 목록 조회 */


### PR DESCRIPTION
Update :: 특정 날짜 기준 한국인 학생의 예약 목록 조회 API

Update :: 관리자 - 특정 날짜 유학생 전체 스케줄 조회 API

Update :: 관리자 - 특정 날짜 전체 유학생 스케줄 조회 API

Update :: 유학생 - 특정 기간 전체 스케줄 조회 API

Feature :: 한국인학생 - 학기별 미팅 목록 결과 조회 API

Etc : 스케줄 컨트롤러 -> std_for_show_sch_by_date 부분은 "관리자 - 전체 유학생 스케줄 조회"라서 다시 수정했습니다.
+) 네이밍 변경 std_for_show_sch_by_date  -> showForeignerSchedules
+) 기존 std_for_show_sch_by_date는 "유학생 - 특정 기간 전체 스케줄 조회"로 변경했습니다.

